### PR TITLE
Feature/24 shorter filenames

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-text-extract",
-  "version": "0.0.0",
+  "version": "0.2.0",
   "type": "module",
   "private": true,
   "description": "The core library for Obsidian Text Extractor plugin",

--- a/lib/src/cache.ts
+++ b/lib/src/cache.ts
@@ -67,8 +67,8 @@ export async function writeCache(
     text,
     libVersion,
     langs,
-    hash: '',
-    size: 0,
+    // hash: '',
+    // size: 0,
   }
   await app.vault.adapter.mkdir(folder)
   return await app.vault.adapter.write(path, JSON.stringify(data))

--- a/lib/src/cache.ts
+++ b/lib/src/cache.ts
@@ -2,10 +2,26 @@ import type { TFile } from 'obsidian'
 import { libVersion } from './globals'
 import type { ExtractedText } from './types'
 import { makeMD5, slugify } from './utils'
-import { isInCache } from './index'
 
 export function getCacheBasePath(): string {
   return `${app.vault.configDir}/plugins/text-extractor/cache`
+}
+
+export async function convertOldCachePaths(): Promise<void> {
+  // Convert old cache files to new format
+  // Recursively list all files in the cache folder
+  const cachePath = getCacheBasePath()
+  const paths = await app.vault.adapter.list(cachePath)
+  for (const dir of paths.folders) {
+    const files = await app.vault.adapter.list(dir)
+    for (const file of files.files) {
+      const hash = file.split('-').pop()?.split('.').shift()
+      if (hash) {
+        const newPath = `${cachePath}/${hash}.json`
+        await app.vault.adapter.rename(file, newPath)
+      }
+    }
+  }
 }
 
 export function getCachePath(file: TFile): {

--- a/lib/src/cache.ts
+++ b/lib/src/cache.ts
@@ -13,7 +13,6 @@ export function getCachePath(file: TFile): {
   folder: string
   fullpath: string
 } {
-  const slug = slugify(file.path)
   const hash = makeMD5(file.path)
   let subFolder = slugify(file.basename).slice(0, 2)
 
@@ -23,7 +22,7 @@ export function getCachePath(file: TFile): {
     subFolder += '_'
   }
   const folder = `${getCacheBasePath()}/${subFolder}`
-  const filename = `${slug}-${hash}.json`
+  const filename = `${hash}.json`
   return {
     folder,
     filename,

--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -4,7 +4,7 @@ import { ocrLangs } from './ocr/ocr-langs'
 import type { TFile } from 'obsidian'
 import type { OcrOptions } from './types'
 import { pdfProcessQueue } from './globals'
-import { getCacheBasePath, getCachePath } from './cache'
+import { convertOldCachePaths, getCacheBasePath, getCachePath } from './cache'
 
 /**
  * Returns a promise that resolves to the text extracted from the file.
@@ -62,7 +62,7 @@ function clearProcessQueue() {
   pdfProcessQueue.clear()
 }
 
-function isInCache(file: TFile): Promise<boolean> {
+async function isInCache(file: TFile): Promise<boolean> {
   const path = getCachePath(file)
   return app.vault.adapter.exists(path.fullpath)
 }
@@ -83,4 +83,5 @@ export {
   removeFromCache,
   getCacheBasePath,
   clearOCRWorkers,
+  convertOldCachePaths,
 }

--- a/lib/src/types.ts
+++ b/lib/src/types.ts
@@ -2,11 +2,11 @@ import type { ocrLangs } from './ocr/ocr-langs'
 
 export type ExtractedText = {
   path: string
-  hash: string
-  size: number
   text: string
   langs: string
   libVersion: string
+  // hash: string
+  // size: number
 }
 
 export type OcrOptions = { langs: Array<typeof ocrLangs[number]> }

--- a/plugin/src/main.ts
+++ b/plugin/src/main.ts
@@ -27,6 +27,7 @@ export default class TextExtractorPlugin extends Plugin {
 
   async onload() {
     await loadSettings(this)
+    await TextExtract.convertOldCachePaths()
     this.addSettingTab(new TextExtractorSettingsTab(this))
     this.registerEvent(
       app.workspace.on('file-menu', (menu, file, _source) => {


### PR DESCRIPTION
Fixes #24 by defining a new shorter path for cache files, using only the hash and no subdirectory. A function at startup will automatically convert all old files.