### PR TITLE
Add support for webp, gif, bmp

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ You're more than welcome to submit PRs, and I will gladly help and mentor :)
 
 Supported files:
 
-- Images (`.png`, `.jpg`, `.jpeg`)
+- Images (`.png`, `.jpg`, `.jpeg`, `.webp`, `.gif`, `.bmp`)
 - PDFs (`.pdf`)
 
 ### Limitations

--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -34,7 +34,8 @@ function isFilePDF(path: string): boolean {
 
 function isFileImage(path: string): boolean {
   return (
-    path.endsWith('.png') || path.endsWith('.jpg') || path.endsWith('.jpeg')
+    path.endsWith('.png') || path.endsWith('.jpg') || path.endsWith('.jpeg') ||
+    path.endsWith('.webp') || path.endsWith('.gif') || path.endsWith('.bmp')
   )
 }
 


### PR DESCRIPTION
According to [list of image formats supported by tesseractjs](https://github.com/tesseract-ocr/tessdoc/blob/main/InputFormats.md#supported-input-formats)
- Support for webp (closed #43), gif and bmp has been added and tested  
- Obsidian does not support tiff and pnm, so they have not been added