### PR TITLE
Add page metadata to PDF text extractions

### DIFF
--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -1,15 +1,20 @@
 use js_sys::Uint8Array;
-use pdf_extract::extract_text_from_mem;
+use pdf_extract::extract_text_from_mem_by_pages;
 use wasm_bindgen::prelude::*;
 
 // mod obsidian;
 
 #[wasm_bindgen]
-pub fn extract_pdf_text(arr: Uint8Array) -> Result<String, JsError> {
-    match extract_text_from_mem(&arr.to_vec()) {
-        Ok(txt) => return Ok(txt),
-        Err(e) => return Err(JsError::new(&e.to_string())),
-    };
+pub fn extract_pdf_text_by_pages(arr: Uint8Array) -> Result<js_sys::Array, JsError> {
+    let pages = extract_text_from_mem_by_pages(&arr.to_vec())
+        .map_err(|e| JsError::new(&e.to_string()))?;
+
+    let result = js_sys::Array::new();
+    for content in pages {
+        result.push(&JsValue::from_str(&content));
+    }
+
+    Ok(result)
 }
 
 // #[wasm_bindgen]

--- a/lib/src/pdf/pdf-manager.ts
+++ b/lib/src/pdf/pdf-manager.ts
@@ -57,7 +57,7 @@ class PDFWorker {
 class PDFManager {
   public async getPdfText(file: TFile): Promise<string> {
     try {
-      return (await pdfProcessQueue.add(() => this.#getPdfText(file))) ?? ''
+      return await pdfProcessQueue.add(() => this.#getPdfText(file)) ?? ''
     } catch (e) {
       console.warn(
         `Text Extractor - Error while extracting text from ${file.basename}`
@@ -93,24 +93,12 @@ class PDFManager {
         const text = res.data.text as string
 
         // Add it to the cache
-        await writeCache(
-          cachePath.folder,
-          cachePath.filename,
-          text,
-          file.path,
-          ''
-        )
+        await writeCache(cachePath.folder, cachePath.filename, text, file.path, '')
         resolve(text)
       } catch (e) {
         // In case of error (unreadable PDF or timeout) just add
         // an empty string to the cache
-        await writeCache(
-          cachePath.folder,
-          cachePath.filename,
-          '',
-          file.path,
-          ''
-        )
+        await writeCache(cachePath.folder, cachePath.filename, '', file.path, '')
         resolve('')
       }
     })

--- a/lib/src/pdf/pdf-worker.ts
+++ b/lib/src/pdf/pdf-worker.ts
@@ -11,14 +11,14 @@ function normalize(text: string) {
 /**
  * Extract text from the PDF by calling into WASM plugin
  * @param pdf pdf buffer
- * @param shouldNormalise true to normalise all spaces/newlines to a single space
+ * @param shouldNormalize true to normalize all spaces/newlines to a single space
  */
-function extract(pdf: Uint8Array, shouldNormalise: boolean) {
+function extract(pdf: Uint8Array, shouldNormalize: boolean) {
   // Extract text by page
   let text = plugin.extract_pdf_text_by_pages(pdf)
 
   // If requested, normalize text
-  if (shouldNormalise) {
+  if (shouldNormalize) {
     text = text.map(normalize)
   }
 
@@ -34,10 +34,10 @@ onmessage = async evt => {
 
   try {
     const pdf = evt.data.data as Uint8Array
-    const shouldNormalise: boolean = !!evt.data.normalize
+    const shouldNormalize: boolean = !!evt.data.normalize
 
     // Perform text extraction
-    const text = extract(pdf, shouldNormalise)
+    const text = extract(pdf, shouldNormalize)
 
     self.postMessage({ text })
   } catch (e) {

--- a/lib/src/pdf/pdf-worker.ts
+++ b/lib/src/pdf/pdf-worker.ts
@@ -41,9 +41,7 @@ onmessage = async evt => {
 
     self.postMessage({ text })
   } catch (e) {
-    console.info(
-      'Text Extractor - Could not extract text from ' + evt.data.name
-    )
+    console.info('Text Extractor - Could not extract text from ' + evt.data.name)
     self.postMessage({ text: '' })
   }
 }


### PR DESCRIPTION
When extracting PDF text, emit page metadata to facilitate deep linking.

Markers are in the form of Obsidian Markdown headings, `# Page N^page=N` (page repeated to avoid risk of this string within the PDF causing confusion; ideally text extractor would provide a more structured view to provide char offsets for the start of each page in a separate field, but that would be a much larger change)

This is the Text Extractor side of https://github.com/scambier/obsidian-omnisearch/pull/507