### PR TITLE
Support the Obsidian 1.13 settings API

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -33,7 +33,7 @@
     "babel-jest": "^27.5.1",
     "builtin-modules": "^3.3.0",
     "jest": "^27.5.1",
-    "obsidian": "^1.8.7",
+    "obsidian": "^1.13.0",
     "prettier": "^2.8.8",
     "rollup": "^2.79.2",
     "rollup-plugin-base64": "^1.0.1",
@@ -44,6 +44,7 @@
     "rollup-plugin-web-worker-loader": "^1.7.0",
     "tslib": "2.3.1",
     "typescript": "^4.9.5",
+    "vite": "^5.4.21",
     "vitest": "^2.1.9"
   },
   "dependencies": {

--- a/lib/pnpm-lock.yaml
+++ b/lib/pnpm-lock.yaml
@@ -76,8 +76,8 @@ importers:
         specifier: ^27.5.1
         version: 27.5.1
       obsidian:
-        specifier: ^1.8.7
-        version: 1.8.7(@codemirror/state@6.4.0)(@codemirror/view@6.23.0)
+        specifier: ^1.13.0
+        version: 1.13.1(@codemirror/state@6.4.0)(@codemirror/view@6.23.0)
       prettier:
         specifier: ^2.8.8
         version: 2.8.8
@@ -108,6 +108,9 @@ importers:
       typescript:
         specifier: ^4.9.5
         version: 4.9.5
+      vite:
+        specifier: ^5.4.21
+        version: 5.4.21(@types/node@20.19.11)(terser@5.43.1)
       vitest:
         specifier: ^2.1.9
         version: 2.1.9(@types/node@20.19.11)(jsdom@16.7.0)(terser@5.43.1)
@@ -840,6 +843,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@vitest/coverage-v8@2.1.9':
     resolution: {integrity: sha512-Z2cOr0ksM00MpEfyVE8KXIYPEcBFxdbLSs56L8PO0QQMxt/6bDj45uQfxoc96v05KW3clk7vvgP0qfDit9DmfQ==}
@@ -1391,15 +1395,6 @@ packages:
 
   fb-watchman@2.0.2:
     resolution: {integrity: sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==}
-
-  fdir@6.5.0:
-    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
-    engines: {node: '>=12.0.0'}
-    peerDependencies:
-      picomatch: ^3 || ^4
-    peerDependenciesMeta:
-      picomatch:
-        optional: true
 
   file-entry-cache@6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
@@ -2074,11 +2069,11 @@ packages:
   nwsapi@2.2.21:
     resolution: {integrity: sha512-o6nIY3qwiSXl7/LuOU0Dmuctd34Yay0yeuZRLFmDPrrdHpXKFndPj3hM+YEPVHYC5fx2otBx4Ilc/gyYSAUaIA==}
 
-  obsidian@1.8.7:
-    resolution: {integrity: sha512-h4bWwNFAGRXlMlMAzdEiIM2ppTGlrh7uGOJS6w4gClrsjc+ei/3YAtU2VdFUlCiPuTHpY4aBpFJJW75S1Tl/JA==}
+  obsidian@1.13.1:
+    resolution: {integrity: sha512-qtTEA2pmhJzhuhJqzbBFRYhpIOqvW+krDYjtFynv66KbxBbumHBlsJfWw3I4jtnK/6fZwbQhCrmmDdRwXmX56w==}
     peerDependencies:
-      '@codemirror/state': ^6.0.0
-      '@codemirror/view': ^6.0.0
+      '@codemirror/state': 6.5.0
+      '@codemirror/view': 6.38.6
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
@@ -2528,10 +2523,6 @@ packages:
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
-  tinyglobby@0.2.15:
-    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
-    engines: {node: '>=12.0.0'}
-
   tinypool@1.1.1:
     resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -2642,26 +2633,21 @@ packages:
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
 
-  vite@7.2.2:
-    resolution: {integrity: sha512-BxAKBWmIbrDgrokdGZH1IgkIk/5mMHDreLDmCJ0qpyJaAteP8NvMhkwr/ZCQNqNH97bw/dANTE9PDzqwJghfMQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
+  vite@5.4.21:
+    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
-      '@types/node': ^20.19.0 || >=22.12.0
-      jiti: '>=1.21.0'
-      less: ^4.0.0
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
       lightningcss: ^1.21.0
-      sass: ^1.70.0
-      sass-embedded: ^1.70.0
-      stylus: '>=0.54.8'
-      sugarss: ^5.0.0
-      terser: ^5.16.0
-      tsx: ^4.8.1
-      yaml: ^2.4.2
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
     peerDependenciesMeta:
       '@types/node':
-        optional: true
-      jiti:
         optional: true
       less:
         optional: true
@@ -2676,10 +2662,6 @@ packages:
       sugarss:
         optional: true
       terser:
-        optional: true
-      tsx:
-        optional: true
-      yaml:
         optional: true
 
   vitest@2.1.9:
@@ -3620,13 +3602,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 1.2.0
 
-  '@vitest/mocker@2.1.9(vite@7.2.2(@types/node@20.19.11)(terser@5.43.1))':
+  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@20.19.11)(terser@5.43.1))':
     dependencies:
       '@vitest/spy': 2.1.9
       estree-walker: 3.0.3
       magic-string: 0.30.18
     optionalDependencies:
-      vite: 7.2.2(@types/node@20.19.11)(terser@5.43.1)
+      vite: 5.4.21(@types/node@20.19.11)(terser@5.43.1)
 
   '@vitest/pretty-format@2.1.9':
     dependencies:
@@ -4209,10 +4191,6 @@ snapshots:
   fb-watchman@2.0.2:
     dependencies:
       bser: 2.1.1
-
-  fdir@6.5.0(picomatch@4.0.3):
-    optionalDependencies:
-      picomatch: 4.0.3
 
   file-entry-cache@6.0.1:
     dependencies:
@@ -5124,7 +5102,7 @@ snapshots:
 
   nwsapi@2.2.21: {}
 
-  obsidian@1.8.7(@codemirror/state@6.4.0)(@codemirror/view@6.23.0):
+  obsidian@1.13.1(@codemirror/state@6.4.0)(@codemirror/view@6.23.0):
     dependencies:
       '@codemirror/state': 6.4.0
       '@codemirror/view': 6.23.0
@@ -5575,11 +5553,6 @@ snapshots:
 
   tinyexec@0.3.2: {}
 
-  tinyglobby@0.2.15:
-    dependencies:
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-
   tinypool@1.1.1: {}
 
   tinyrainbow@1.2.0: {}
@@ -5676,10 +5649,9 @@ snapshots:
       debug: 4.4.1
       es-module-lexer: 1.7.0
       pathe: 1.1.2
-      vite: 7.2.2(@types/node@20.19.11)(terser@5.43.1)
+      vite: 5.4.21(@types/node@20.19.11)(terser@5.43.1)
     transitivePeerDependencies:
       - '@types/node'
-      - jiti
       - less
       - lightningcss
       - sass
@@ -5688,17 +5660,12 @@ snapshots:
       - sugarss
       - supports-color
       - terser
-      - tsx
-      - yaml
 
-  vite@7.2.2(@types/node@20.19.11)(terser@5.43.1):
+  vite@5.4.21(@types/node@20.19.11)(terser@5.43.1):
     dependencies:
       esbuild: 0.25.12
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
       postcss: 8.5.6
       rollup: 4.49.0
-      tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 20.19.11
       fsevents: 2.3.3
@@ -5707,7 +5674,7 @@ snapshots:
   vitest@2.1.9(@types/node@20.19.11)(jsdom@16.7.0)(terser@5.43.1):
     dependencies:
       '@vitest/expect': 2.1.9
-      '@vitest/mocker': 2.1.9(vite@7.2.2(@types/node@20.19.11)(terser@5.43.1))
+      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@20.19.11)(terser@5.43.1))
       '@vitest/pretty-format': 2.1.9
       '@vitest/runner': 2.1.9
       '@vitest/snapshot': 2.1.9
@@ -5723,14 +5690,13 @@ snapshots:
       tinyexec: 0.3.2
       tinypool: 1.1.1
       tinyrainbow: 1.2.0
-      vite: 7.2.2(@types/node@20.19.11)(terser@5.43.1)
+      vite: 5.4.21(@types/node@20.19.11)(terser@5.43.1)
       vite-node: 2.1.9(@types/node@20.19.11)(terser@5.43.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.19.11
       jsdom: 16.7.0
     transitivePeerDependencies:
-      - jiti
       - less
       - lightningcss
       - msw
@@ -5740,8 +5706,6 @@ snapshots:
       - sugarss
       - supports-color
       - terser
-      - tsx
-      - yaml
 
   w3c-hr-time@1.0.2:
     dependencies:

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -20,7 +20,7 @@
     "esbuild": "0.14.47",
     "esbuild-plugin-copy": "1.3.0",
     "esbuild-svelte": "^0.7.4",
-    "obsidian": "^1.8.7",
+    "obsidian": "^1.13.0",
     "prettier": "^2.8.8",
     "svelte": "^3.59.2",
     "svelte-check": "^2.10.3",

--- a/plugin/pnpm-lock.yaml
+++ b/plugin/pnpm-lock.yaml
@@ -37,8 +37,8 @@ importers:
         specifier: ^0.7.4
         version: 0.7.4(esbuild@0.14.47)(svelte@3.59.2)
       obsidian:
-        specifier: ^1.8.7
-        version: 1.8.7(@codemirror/state@6.5.2)(@codemirror/view@6.36.7)
+        specifier: ^1.13.0
+        version: 1.13.1(@codemirror/state@6.5.0)(@codemirror/view@6.38.6)
       prettier:
         specifier: ^2.8.8
         version: 2.8.8
@@ -63,11 +63,14 @@ importers:
 
 packages:
 
+  '@codemirror/state@6.5.0':
+    resolution: {integrity: sha512-MwBHVK60IiIHDcoMet78lxt6iw5gJOGSbNbOIVBHWVXIH4/Nq1+GQgLLGgI1KlnN86WDXsPudVaqYHKBIx7Eyw==}
+
   '@codemirror/state@6.5.2':
     resolution: {integrity: sha512-FVqsPqtPWKVVL3dPSxy8wEF/ymIEuVzF1PK3VbUgrxXpJUSHQWWZz4JMToquRxnkw+36LTamCZG2iua2Ptq0fA==}
 
-  '@codemirror/view@6.36.7':
-    resolution: {integrity: sha512-kCWGW/chWGPgZqfZ36Um9Iz0X2IVpmCjg1P/qY6B6a2ecXtWRRAigmpJ6YgUQ5lTWXMyyVdfmpzhLZmsZQMbtg==}
+  '@codemirror/view@6.38.6':
+    resolution: {integrity: sha512-qiS0z1bKs5WOvHIAC0Cybmv4AJSkAXgX5aD6Mqd2epSLlVJsQl8NG23jCVouIgkh4All/mrbdsf2UOLFnJw0tw==}
 
   '@eslint-community/eslint-utils@4.7.0':
     resolution: {integrity: sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==}
@@ -154,36 +157,42 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.1':
     resolution: {integrity: sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.1':
     resolution: {integrity: sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.1':
     resolution: {integrity: sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.1':
     resolution: {integrity: sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.1':
     resolution: {integrity: sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.1':
     resolution: {integrity: sha512-RFzklRvmc3PkjKjry3hLF9wD7ppR4AKcWNzH7kXR7GUe0Igb3Nz8fyPwtZCSquGrhU5HhUNDr/mKBqj7tqA2Vw==}
@@ -292,6 +301,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -375,6 +385,9 @@ packages:
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  crelt@1.0.7:
+    resolution: {integrity: sha512-aK6BbWfhf4U/wCcLHKPJl/xa6VkVstRaPywWtMKGwuOLc/wZTyQYuoxgvZnNsBvv7Kg3YTBQYYBCggcviQczuA==}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -665,7 +678,7 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   globals@13.24.0:
     resolution: {integrity: sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==}
@@ -808,11 +821,11 @@ packages:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
 
-  obsidian@1.8.7:
-    resolution: {integrity: sha512-h4bWwNFAGRXlMlMAzdEiIM2ppTGlrh7uGOJS6w4gClrsjc+ei/3YAtU2VdFUlCiPuTHpY4aBpFJJW75S1Tl/JA==}
+  obsidian@1.13.1:
+    resolution: {integrity: sha512-qtTEA2pmhJzhuhJqzbBFRYhpIOqvW+krDYjtFynv66KbxBbumHBlsJfWw3I4jtnK/6fZwbQhCrmmDdRwXmX56w==}
     peerDependencies:
-      '@codemirror/state': ^6.0.0
-      '@codemirror/view': ^6.0.0
+      '@codemirror/state': 6.5.0
+      '@codemirror/view': 6.38.6
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
@@ -1119,13 +1132,18 @@ packages:
 
 snapshots:
 
+  '@codemirror/state@6.5.0':
+    dependencies:
+      '@marijn/find-cluster-break': 1.0.2
+
   '@codemirror/state@6.5.2':
     dependencies:
       '@marijn/find-cluster-break': 1.0.2
 
-  '@codemirror/view@6.36.7':
+  '@codemirror/view@6.38.6':
     dependencies:
       '@codemirror/state': 6.5.2
+      crelt: 1.0.7
       style-mod: 4.1.2
       w3c-keyname: 2.2.8
 
@@ -1429,6 +1447,8 @@ snapshots:
   color-name@1.1.4: {}
 
   concat-map@0.0.1: {}
+
+  crelt@1.0.7: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -1829,10 +1849,10 @@ snapshots:
 
   normalize-path@3.0.0: {}
 
-  obsidian@1.8.7(@codemirror/state@6.5.2)(@codemirror/view@6.36.7):
+  obsidian@1.13.1(@codemirror/state@6.5.0)(@codemirror/view@6.38.6):
     dependencies:
-      '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.36.7
+      '@codemirror/state': 6.5.0
+      '@codemirror/view': 6.38.6
       '@types/codemirror': 5.60.8
       moment: 2.29.4
 

--- a/plugin/src/settings.ts
+++ b/plugin/src/settings.ts
@@ -1,6 +1,13 @@
 import TextExtractorPlugin from './main'
 import { writable } from 'svelte/store'
-import { Notice, Platform, PluginSettingTab, Setting } from 'obsidian'
+import {
+  Notice,
+  Platform,
+  PluginSettingTab,
+  Setting,
+  requireApiVersion,
+  type SettingDefinitionItem,
+} from 'obsidian'
 import LangSelector from './components/LangSelector.svelte'
 import {
   getOcrLangs,
@@ -12,6 +19,15 @@ interface TextExtractorSettings {
   ocrLanguages: ReturnType<typeof getOcrLangs>[number][]
   rightClickMenu: boolean
   useSystemOCR: boolean
+}
+
+function createClearCacheDescription(): DocumentFragment {
+  const description = new DocumentFragment()
+  description.createSpan({}, span => {
+    span.innerHTML = `Erase all Text Extractor cache data. Use this if you want to re-extract all your files, e.g after a change in language settings.<br>
+      Be careful that re-extracting all your files can take a long time.`
+  })
+  return description
 }
 
 export class TextExtractorSettingsTab extends PluginSettingTab {
@@ -26,6 +42,78 @@ export class TextExtractorSettingsTab extends PluginSettingTab {
       clearOCRWorkers()
       await saveSettings(this.plugin)
     })
+  }
+
+  getSettingDefinitions(): SettingDefinitionItem[] {
+    if (!requireApiVersion('1.13.0')) {
+      return []
+    }
+
+    return [
+      {
+        type: 'group',
+        heading: 'Text Extractor - Settings',
+        items: [
+          {
+            name: 'Use system OCR',
+            desc: 'If enabled, Text Extractor will use the system OCR instead of Tesseract. The OCR language will be detected automatically.',
+            visible: Platform.isDesktopApp && Platform.isMacOS,
+            render: setting => {
+              setting.addToggle(toggle => {
+                toggle.setValue(settings.useSystemOCR).onChange(async value => {
+                  settings.useSystemOCR = value
+                  if (value) {
+                    clearOCRWorkers()
+                  }
+                  await saveSettings(this.plugin)
+                })
+              })
+            },
+          },
+          {
+            name: 'OCR Languages',
+            desc: `A list of languages to use for OCR. e.g. if your vault contains documents in English and French, you'd want to add 'eng' and 'fra' here.
+              This setting only applies to images, not PDFs. You may have to clear the cache after changing this setting.`,
+            render: setting => {
+              const selector = new LangSelector({
+                target: setting.controlEl,
+              })
+              return () => selector.$destroy()
+            },
+          },
+          {
+            name: 'Right click menu',
+            desc: 'Add "Text Extractor" actions to the right click menu in the file explorer.',
+            render: setting => {
+              setting.addToggle(toggle => {
+                toggle.setValue(settings.rightClickMenu).onChange(async value => {
+                  settings.rightClickMenu = value
+                  await saveSettings(this.plugin)
+                })
+              })
+            },
+          },
+        ],
+      },
+      {
+        type: 'group',
+        heading: 'Danger Zone',
+        items: [
+          {
+            name: 'Clear cache data',
+            desc: createClearCacheDescription(),
+            render: setting => {
+              setting.addButton(button => {
+                button.setButtonText('Clear cache').onClick(async () => {
+                  await app.vault.adapter.rmdir(getCacheBasePath(), true)
+                  new Notice('Text Extract - Cache cleared.')
+                })
+              })
+            },
+          },
+        ],
+      },
+    ]
   }
 
   display(): void {
@@ -85,11 +173,7 @@ export class TextExtractorSettingsTab extends PluginSettingTab {
     //#region Danger Zone
     new Setting(containerEl).setName('Danger Zone').setHeading()
 
-    const resetCacheDesc = new DocumentFragment()
-    resetCacheDesc.createSpan({}, span => {
-      span.innerHTML = `Erase all Text Extractor cache data. Use this if you want to re-extract all your files, e.g after a change in language settings.<br>
-        Be careful that re-extracting all your files can take a long time.`
-    })
+    const resetCacheDesc = createClearCacheDescription()
     new Setting(containerEl)
       .setName('Clear cache data')
       .setDesc(resetCacheDesc)


### PR DESCRIPTION
This migrates Text Extractor's settings tab to Obsidian 1.13's declarative `getSettingDefinitions()` API while retaining `display()` as the legacy fallback. The new definitions preserve the macOS system OCR toggle, custom OCR language selector, right-click menu toggle, Danger Zone grouping, cache-clear action, and selector cleanup behavior.

The plugin and library Obsidian development dependencies move to `^1.13.0`. A follow-up toolchain commit also adds Vite `^5.4.21` alongside Vitest `^2.1.9` and refreshes the lockfiles so the test runner resolves a compatible Vite version.

Validation: all 13 Vitest tests pass, along with both the library/native build and plugin build.